### PR TITLE
✨ Feature: Added statename-checkbox Option

### DIFF
--- a/swe.js
+++ b/swe.js
@@ -57,6 +57,7 @@ function loadMap() {
         fetch('state-abbreviation.json')
         .then(response => response.json())
         .then(stateAbbreviations => {
+            var stateNameMarkers = L.layerGroup();
             var stateLayer = L.geoJSON(data, {
                 style: function (feature) {
                     return {
@@ -75,7 +76,7 @@ function loadMap() {
                                 html: `<strong>${stateName}</strong>`,
                                 iconSize: [100, 40]
                             })
-                        }).addTo(map);
+                        }).addTo(stateNameMarkers);
 
                         function updateLabelContent() {
                             const zoomLevel = map.getZoom();
@@ -92,7 +93,7 @@ function loadMap() {
                                 marker.remove();
                             } else {
                                 if (!map.hasLayer(marker)) {
-                                    marker.addTo(map);
+                                    marker.addTo(stateNameMarkers);
                                 }
                             }
                         }
@@ -104,7 +105,9 @@ function loadMap() {
             }).addTo(map);
 
             stateLayer.bringToFront();
+            stateNameMarkers.addTo(map);
             layercontrol.addOverlay(stateLayer, "State Boundaries");
+            layercontrol.addOverlay(stateNameMarkers, "State Names");
             layercontrol.addOverlay(wmslayer, "Predicted SWE " + date);
         })
         .catch(error => {


### PR DESCRIPTION
I’ve added a statename-checkbox option to toggle the visibility of state names on the map. This should help make the blocked areas more visible when state names are hidden. 

Changes:
✅ Added a checkbox to toggle state name visibility.
🔧 Updated the UI logic.

Before:
<img width="1728" alt="Screenshot 2024-12-01 at 6 56 10 PM" src="https://github.com/user-attachments/assets/666412a7-bd7c-4675-bb65-8057d6f59787">

After:
<img width="1728" alt="Screenshot 2024-12-01 at 6 56 31 PM" src="https://github.com/user-attachments/assets/6ec8ad2e-748c-40ff-850c-9ca3adb40325">



https://github.com/user-attachments/assets/fd431869-846d-4f71-8f13-7adb70639e5c
